### PR TITLE
migrate rdbms role - fixes for rhel9

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ See the [requirements for `cloudera-labs/cloudera.cluster`](https://github.com/w
 
 | Name | Type | Version |
 |------|------|---------|
-| `community.mysql` | collection | `3.1.0` |
-| `community.postgresql` | collection | `1.6.1` |
+| `community.mysql` | collection | `3.8.0` |
+| `community.postgresql` | collection | `3.3.0` |
 | `freeipa.ansible_freeipa` | collection | `1.11.1` |
-| `geerlingguy.postgresql` | role | `2.2.0` |
+| `geerlingguy.postgresql` | role | `3.3.0` |
 | `geerlingguy.mysql` (patched) | role | `master` |
 
 **Terraform**

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,7 +16,7 @@
 
 namespace:  cloudera
 name:       exe
-version:    2.3.0
+version:    2.4.0
 readme:     README.md
 authors:    []
 

--- a/playbooks/pvc_base_prereqs_ext.yml
+++ b/playbooks/pvc_base_prereqs_ext.yml
@@ -131,7 +131,7 @@
   gather_facts: no
   become: yes
   roles:
-    - role: cloudera.cluster.prereqs.mysql_connector
+    - role: cloudera.exe.rdbms.client.mysql_connector
       when: database_type == 'mysql' or database_type == 'mariadb'
   tags:
     - mysql_connector
@@ -142,7 +142,7 @@
   gather_facts: no
   become: yes
   roles:
-    - role: cloudera.cluster.prereqs.oracle_connector
+    - role: cloudera.exe.rdbms.client.oracle_connector
       when: database_type == 'oracle'
   tags:
     - oracle_connector
@@ -153,7 +153,7 @@
   gather_facts: no
   become: yes
   roles:
-    - role: cloudera.cluster.prereqs.postgresql_connector
+    - role: cloudera.exe.rdbms.client.postgresql_connector
       when: database_type == 'postgresql'
   tags:
     - postgresql_connector
@@ -260,7 +260,7 @@
   hosts: "{{ target | default('db_server') }}"
   become: yes
   roles:
-    - cloudera.cluster.infrastructure.rdbms
+    - cloudera.exe.rdbms.server
   tags:
     - database
     - default_cluster

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 
-# Copyright 2023 Cloudera, Inc.
+# Copyright 2024 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 roles:
   - name: geerlingguy.postgresql
-    version: 2.2.0
+    version: 3.5.0
 
-  - src: https://github.com/dbeech/ansible-role-mysql
+  - src: https://github.com/clevesque/ansible-role-mysql
     version: master
 
 collections:
@@ -45,11 +45,11 @@ collections:
   - name: ansible.posix
     version: 1.3.0
   - name: community.crypto
-    version: 2.2.1
+    version: 2.17.1
   - name: community.mysql
-    version: 3.1.0
+    version: 3.8.0
   - name: community.postgresql
-    version: 1.6.1
+    version: 3.3.0
   - name: freeipa.ansible_freeipa
     version: 1.11.1
   - name: cloud.terraform

--- a/roles/rdbms/client/mysql_connector/defaults/main.yml
+++ b/roles/rdbms/client/mysql_connector/defaults/main.yml
@@ -1,0 +1,22 @@
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+local_temp_dir: '/tmp'
+mysql_connector_url: https://cdn.mysql.com//Downloads/Connector-J/mysql-connector-java-5.1.49.zip
+mysql_connector_checksum: md5:5ecd588e13f14de07faa5c67f5caf3f1
+mysql_connector_download_dir: "{{ local_temp_dir }}"
+mysql_connector_extract_dir: "{{ local_temp_dir }}"
+mysql_connector_local_path: "{{ mysql_connector_extract_dir }}/mysql-connector-java-5.1.49/mysql-connector-java-5.1.49-bin.jar"

--- a/roles/rdbms/client/mysql_connector/meta/main.yml
+++ b/roles/rdbms/client/mysql_connector/meta/main.yml
@@ -1,0 +1,15 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---

--- a/roles/rdbms/client/mysql_connector/tasks/main.yml
+++ b/roles/rdbms/client/mysql_connector/tasks/main.yml
@@ -1,0 +1,60 @@
+# Copyright 2023 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Download MySQL Connector/J
+  get_url:
+    url: "{{ mysql_connector_url }}"
+    dest: "{{ mysql_connector_download_dir }}/mysql-connector-java.zip"
+    checksum: "{{ mysql_connector_checksum }}"
+    mode: 0644
+  become: no
+  run_once: true
+  delegate_to: localhost
+
+- name: Create /usr/share/java directory
+  file:
+    path: /usr/share/java
+    state: directory
+    mode: 0755
+
+- name: Install unzip package
+  ansible.builtin.package:
+    lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(60, omit) }}"
+    name: unzip
+    state: present
+
+- name: Extract MySQL Connector/J zip file
+  unarchive:
+    src: "{{ mysql_connector_download_dir }}/mysql-connector-java.zip"
+    dest: "{{ mysql_connector_extract_dir }}"
+    exclude:
+      - src
+
+- name: Copy MySQL Connector/J jar file to correct location
+  copy:
+    src: "{{ mysql_connector_local_path }}"
+    dest: /usr/share/java/mysql-connector-java.jar
+    remote_src: yes
+    mode: 0644
+
+## Fix for RHEL8,9
+- name: Install Mysql packages for python - PyMySQL
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version >= "8"
+  shell: /usr/local/bin/pip install PyMySQL --force-reinstall --ignore-installed
+  ignore_errors: true
+      

--- a/roles/rdbms/client/mysql_connector/templates/my_config.h
+++ b/roles/rdbms/client/mysql_connector/templates/my_config.h
@@ -1,0 +1,355 @@
+/* Copyright (c) 2009, 2021, Oracle and/or its affiliates. 
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License, version 2.0,
+  as published by the Free Software Foundation.
+  
+  This program is also distributed with certain software (including
+  but not limited to OpenSSL) that is licensed under separate terms,
+  as designated in a particular file or component or in included license
+  documentation.  The authors of MySQL hereby grant you an additional
+  permission to link the program and your derivative works with the
+  separately licensed software that they have included with MySQL.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License, version 2.0, for more details.
+  
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+  
+ #ifndef MY_CONFIG_H
+ #define MY_CONFIG_H
+  
+ /*
+  * From configure.cmake, in order of appearance
+  */
+  
+ /* Libraries */
+ #define HAVE_LIBM 1
+ /* #undef HAVE_LIBNSL */
+ #define HAVE_LIBCRYPT 1
+ /* #undef HAVE_LIBSOCKET */
+ #define HAVE_LIBDL 1
+ #define HAVE_LIBRT 1
+ /* #undef HAVE_LIBWRAP */
+ /* #undef HAVE_LIBWRAP_PROTOTYPES */
+  
+ /* Header files */
+ #define HAVE_ALLOCA_H 1
+ #define HAVE_ARPA_INET_H 1
+ #define HAVE_DLFCN_H 1
+ #define HAVE_EXECINFO_H 1
+ #define HAVE_FPU_CONTROL_H 1
+ #define HAVE_GRP_H 1
+ #define HAVE_LANGINFO_H 1
+ #define HAVE_MALLOC_H 1
+ #define HAVE_NETINET_IN_H 1
+ #define HAVE_POLL_H 1
+ #define HAVE_PWD_H 1
+ #define HAVE_STRINGS_H 1
+ #define HAVE_SYS_CDEFS_H 1
+ #define HAVE_SYS_IOCTL_H 1
+ #define HAVE_SYS_MMAN_H 1
+ #define HAVE_SYS_PRCTL_H 1
+ #define HAVE_SYS_RESOURCE_H 1
+ #define HAVE_SYS_SELECT_H 1
+ #define HAVE_SYS_SOCKET_H 1
+ #define HAVE_TERM_H 1
+ #define HAVE_TERMIOS_H 1
+ #define HAVE_TERMIO_H 1
+ #define HAVE_UNISTD_H 1
+ #define HAVE_SYS_WAIT_H 1
+ #define HAVE_SYS_PARAM_H 1
+ #define HAVE_FNMATCH_H 1
+ #define HAVE_SYS_UN_H 1
+ #define HAVE_SASL_SASL_H 1
+  
+ /* Functions */
+ /* #undef HAVE_ALIGNED_MALLOC */
+ #define HAVE_BACKTRACE 1
+ #define HAVE_INDEX 1
+ #define HAVE_CHOWN 1
+ #define HAVE_CUSERID 1
+ /* #undef HAVE_DIRECTIO */
+ #define HAVE_FTRUNCATE 1
+ #define HAVE_FCHMOD 1
+ #define HAVE_FCNTL 1
+ #define HAVE_FDATASYNC 1
+ #define HAVE_DECL_FDATASYNC 1
+ #define HAVE_FEDISABLEEXCEPT 1
+ #define HAVE_FSYNC 1
+ /* #undef HAVE_GETHRTIME */
+ #define HAVE_GETPASS 1
+ /* #undef HAVE_GETPASSPHRASE */
+ #define HAVE_GETPWNAM 1
+ #define HAVE_GETPWUID 1
+ #define HAVE_GETRUSAGE 1
+ #define HAVE_INITGROUPS 1
+ /* #undef HAVE_ISSETUGID */
+ #define HAVE_GETUID 1
+ #define HAVE_GETEUID 1
+ #define HAVE_GETGID 1
+ #define HAVE_GETEGID 1
+ /* #undef HAVE_LSAN_DO_RECOVERABLE_LEAK_CHECK */
+ #define HAVE_MADVISE 1
+ #define HAVE_MALLOC_INFO 1
+ #define HAVE_MLOCK 1
+ #define HAVE_MLOCKALL 1
+ #define HAVE_MMAP64 1
+ #define HAVE_POLL 1
+ #define HAVE_POSIX_FALLOCATE 1
+ #define HAVE_POSIX_MEMALIGN 1
+ #define HAVE_PTHREAD_CONDATTR_SETCLOCK 1
+ #define HAVE_PTHREAD_GETAFFINITY_NP 1
+ #define HAVE_PTHREAD_SIGMASK 1
+ #define HAVE_SLEEP 1
+ #define HAVE_STPCPY 1
+ #define HAVE_STPNCPY 1
+ /* #undef HAVE_STRLCPY */
+ /* #undef HAVE_STRLCAT */
+ #define HAVE_STRSIGNAL 1
+ /* #undef HAVE_TELL */
+ #define HAVE_VASPRINTF 1
+ #define HAVE_MEMALIGN 1
+ #define HAVE_NL_LANGINFO 1
+ /* #undef HAVE_HTONLL */
+ #define HAVE_EPOLL 1
+  
+ /* WL2373 */
+ #define HAVE_SYS_TIME_H 1
+ #define HAVE_SYS_TIMES_H 1
+ #define HAVE_TIMES 1
+ #define HAVE_GETTIMEOFDAY 1
+  
+ /* Symbols */
+ #define HAVE_LRAND48 1
+ #define GWINSZ_IN_SYS_IOCTL 1
+ #define FIONREAD_IN_SYS_IOCTL 1
+ /* #undef FIONREAD_IN_SYS_FILIO */
+ #define HAVE_MADV_DONTDUMP 1
+ #define HAVE_O_TMPFILE
+  
+ /* #undef HAVE_KQUEUE */
+ #define HAVE_SETNS 1
+ /* #undef HAVE_KQUEUE_TIMERS */
+ #define HAVE_POSIX_TIMERS 1
+  
+ /* Endianess */
+ /* #undef WORDS_BIGENDIAN */
+ #define HAVE_ENDIAN_CONVERSION_MACROS 1
+  
+ /* Type sizes */
+ #define SIZEOF_VOIDP     8
+ #define SIZEOF_CHARP     8
+ #define SIZEOF_LONG      8
+ #define SIZEOF_SHORT     2
+ #define SIZEOF_INT       4
+ #define SIZEOF_LONG_LONG 8
+ #define SIZEOF_TIME_T    8
+ #define HAVE_ULONG 1
+ #define HAVE_U_INT32_T 1
+ #define HAVE_TM_GMTOFF 1
+  
+ /* Support for tagging symbols with __attribute__((visibility("hidden"))) */
+ #define HAVE_VISIBILITY_HIDDEN 1
+  
+ /* Code tests*/
+ #define HAVE_CLOCK_GETTIME 1
+ #define HAVE_CLOCK_REALTIME 1
+ #define STACK_DIRECTION -1
+ #define TIME_WITH_SYS_TIME 1
+ /* #undef NO_FCNTL_NONBLOCK */
+ #define HAVE_PAUSE_INSTRUCTION 1
+ /* #undef HAVE_FAKE_PAUSE_INSTRUCTION */
+ /* #undef HAVE_HMT_PRIORITY_INSTRUCTION */
+ #define HAVE_ABI_CXA_DEMANGLE 1
+ #define HAVE_BUILTIN_UNREACHABLE 1
+ #define HAVE_BUILTIN_EXPECT 1
+ #define HAVE_BUILTIN_STPCPY 1
+ #define HAVE_GCC_SYNC_BUILTINS 1
+ /* #undef HAVE_VALGRIND */
+ #define HAVE_SYS_GETTID 1
+ /* #undef HAVE_PTHREAD_GETTHREADID_NP */
+ /* #undef HAVE_PTHREAD_THREADID_NP */
+ #define HAVE_INTEGER_PTHREAD_SELF 1
+ #define HAVE_PTHREAD_SETNAME_NP 1
+  
+ /* IPV6 */
+ /* #undef HAVE_NETINET_IN6_H */
+ /* #undef HAVE_STRUCT_IN6_ADDR */
+  
+ /*
+  * Platform specific CMake files
+  */
+ #define MACHINE_TYPE "x86_64"
+ /* #undef LINUX_ALPINE */
+ /* #undef LINUX_SUSE */
+ #define HAVE_LINUX_LARGE_PAGES 1
+ /* #undef HAVE_SOLARIS_LARGE_PAGES */
+ /* #undef HAVE_SOLARIS_ATOMIC */
+ /* #undef WITH_SYSTEMD_DEBUG */
+ #define SYSTEM_TYPE "Linux"
+ /* This should mean case insensitive file system */
+ /* #undef FN_NO_CASE_SENSE */
+  
+ /*
+  * From main CMakeLists.txt
+  */
+ /* #undef CHECK_ERRMSG_FORMAT */
+ #define MAX_INDEXES 64U
+ /* #undef WITH_INNODB_MEMCACHED */
+ /* #undef ENABLE_MEMCACHED_SASL */
+ /* #undef ENABLE_MEMCACHED_SASL_PWDB */
+ #define ENABLED_PROFILING 1
+ /* #undef HAVE_ASAN */
+ /* #undef HAVE_LSAN */
+ /* #undef HAVE_UBSAN */
+ /* #undef HAVE_TSAN */
+ /* #undef ENABLED_LOCAL_INFILE */
+ /* #undef KERBEROS_LIB_CONFIGURED */
+ #define SCRAM_LIB_CONFIGURED
+ /* #undef WITH_HYPERGRAPH_OPTIMIZER */
+  
+ /* Lock Order */
+ /* #undef WITH_LOCK_ORDER */
+  
+ /* Character sets and collations */
+ #define DEFAULT_MYSQL_HOME "/usr/local/mysql"
+ #define SHAREDIR "/usr/local/mysql/share"
+ #define DEFAULT_BASEDIR "/usr/local/mysql"
+ #define MYSQL_DATADIR "/usr/local/mysql/data"
+ #define MYSQL_KEYRINGDIR "/usr/local/mysql/keyring"
+ #define DEFAULT_CHARSET_HOME "/usr/local/mysql"
+ #define PLUGINDIR "/usr/local/mysql/lib/plugin"
+ #define DEFAULT_SYSCONFDIR "/usr/local/mysql/etc"
+ #define DEFAULT_TMPDIR P_tmpdir
+ /*
+  * Readline
+  */
+ #define HAVE_MBSTATE_T
+ #define HAVE_LANGINFO_CODESET
+ #define HAVE_WCSDUP
+ #define HAVE_WCHAR_T 1
+ #define HAVE_WINT_T 1
+ #define HAVE_CURSES_H 1
+ /* #undef HAVE_NCURSES_H */
+ #define USE_LIBEDIT_INTERFACE 1
+ #define HAVE_HIST_ENTRY 1
+ #define USE_NEW_EDITLINE_INTERFACE 1
+ #define EDITLINE_HAVE_COMPLETION_CHAR 1
+ /* #undef EDITLINE_HAVE_COMPLETION_INT */
+  
+  
+ /*
+  * Libedit
+  */
+ #define HAVE_GETLINE 1
+ /* #undef HAVE___SECURE_GETENV */
+ #define HAVE_SECURE_GETENV 1
+ /* #undef HAVE_VIS */
+ /* #undef HAVE_UNVIS */
+ /* #undef HAVE_GETPW_R_DRAFT */
+ #define HAVE_GETPW_R_POSIX
+  
+ /*
+  * Character sets
+  */
+ #define MYSQL_DEFAULT_CHARSET_NAME "utf8mb4"
+ #define MYSQL_DEFAULT_COLLATION_NAME "utf8mb4_0900_ai_ci"
+  
+ /*
+  * Performance schema
+  */
+ #define WITH_PERFSCHEMA_STORAGE_ENGINE 1
+ /* #undef DISABLE_PSI_THREAD */
+ /* #undef DISABLE_PSI_MUTEX */
+ /* #undef DISABLE_PSI_RWLOCK */
+ /* #undef DISABLE_PSI_COND */
+ /* #undef DISABLE_PSI_FILE */
+ /* #undef DISABLE_PSI_TABLE */
+ /* #undef DISABLE_PSI_SOCKET */
+ /* #undef DISABLE_PSI_STAGE */
+ /* #undef DISABLE_PSI_STATEMENT */
+ /* #undef DISABLE_PSI_SP */
+ /* #undef DISABLE_PSI_PS */
+ /* #undef DISABLE_PSI_IDLE */
+ /* #undef DISABLE_PSI_ERROR */
+ /* #undef DISABLE_PSI_STATEMENT_DIGEST */
+ /* #undef DISABLE_PSI_METADATA */
+ /* #undef DISABLE_PSI_MEMORY */
+ /* #undef DISABLE_PSI_TRANSACTION */
+  
+ /*
+  * MySQL version
+  */
+ #define MYSQL_VERSION_MAJOR 8
+ #define MYSQL_VERSION_MINOR 0
+ #define MYSQL_VERSION_PATCH 25
+ #define MYSQL_VERSION_EXTRA ""
+ #define PACKAGE "mysql"
+ #define PACKAGE_VERSION "8.0.25"
+ #define VERSION "8.0.25"
+ #define PROTOCOL_VERSION 10
+  
+ /*
+  * CPU info
+  */
+ #define CPU_LEVEL1_DCACHE_LINESIZE 64
+  
+  
+ /*
+  * NDB
+  */
+ /* #undef HAVE_GETRLIMIT */
+ /* #undef WITH_NDBCLUSTER_STORAGE_ENGINE */
+ /* #undef HAVE_PTHREAD_SETSCHEDPARAM */
+  
+ /*
+  * Other
+  */
+ /* #undef EXTRA_DEBUG */
+ #define HANDLE_FATAL_SIGNALS 1
+  
+ /*
+  * Hardcoded values needed by libevent/NDB/memcached
+  */
+ #define HAVE_FCNTL_H 1
+ #define HAVE_GETADDRINFO 1
+ #define HAVE_INTTYPES_H 1
+ /* libevent's select.c is not Windows compatible */
+ #ifndef _WIN32
+ #define HAVE_SELECT 1
+ #endif
+ #define HAVE_SIGNAL_H 1
+ #define HAVE_STDARG_H 1
+ #define HAVE_STDINT_H 1
+ #define HAVE_STDLIB_H 1
+ #define HAVE_STRTOK_R 1
+ #define HAVE_STRTOLL 1
+ #define HAVE_SYS_STAT_H 1
+ #define HAVE_SYS_TYPES_H 1
+ #define SIZEOF_CHAR 1
+  
+ /* For --secure-file-priv */
+ #define DEFAULT_SECURE_FILE_PRIV_DIR "NULL"
+ #define HAVE_LIBNUMA 1
+  
+ /* For default value of --early_plugin_load */
+ /* #undef DEFAULT_EARLY_PLUGIN_LOAD */
+  
+ /* For default value of --partial_revokes */
+ #define DEFAULT_PARTIAL_REVOKES 0
+  
+ #define SO_EXT ".so"
+  
+  
+ /* From libmysql/CMakeLists.txt */
+ #define HAVE_UNIX_DNS_SRV 1
+ /* #undef HAVE_WIN32_DNS_SRV */
+  
+ /* ARM crc32 support */
+ /* #undef HAVE_ARMV8_CRC32_INTRINSIC */
+  
+ #endif

--- a/roles/rdbms/client/oracle_connector/defaults/main.yml
+++ b/roles/rdbms/client/oracle_connector/defaults/main.yml
@@ -1,0 +1,22 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+maven_repo: "https://repo1.maven.org/maven2"
+
+oracle_connector_group_id: com.oracle.database.jdbc
+oracle_connector_artifact_id: ojdbc8
+oracle_connector_version: 19.7.0.0
+oracle_connector_maven_url: "{{ maven_repo }}"

--- a/roles/rdbms/client/oracle_connector/meta/main.yml
+++ b/roles/rdbms/client/oracle_connector/meta/main.yml
@@ -1,0 +1,15 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---

--- a/roles/rdbms/client/oracle_connector/tasks/main.yml
+++ b/roles/rdbms/client/oracle_connector/tasks/main.yml
@@ -1,0 +1,85 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Setup the Oracle JDBC Driver
+  block:
+
+    - name: Download Oracle Connector
+      maven_artifact:
+        group_id: "{{ oracle_connector_group_id }}"
+        artifact_id: "{{ oracle_connector_artifact_id }}"
+        version: "{{ oracle_connector_version }}"
+        dest: "{{ local_temp_dir }}/{{ oracle_connector_artifact_id }}-connector-java-{{ oracle_connector_version }}.jar"
+        repository_url: "{{ oracle_connector_maven_url }}"
+      become: no
+      run_once: true
+      connection: local
+      delegate_to: localhost
+
+    - name: Create /usr/share/java directory
+      file:
+        path: /usr/share/java
+        state: directory
+        mode: 0755
+
+    - name: Copy Oracle Connector jar file to correct location
+      copy:
+        src: "{{ local_temp_dir }}/{{ oracle_connector_artifact_id }}-connector-java-{{ oracle_connector_version }}.jar"
+        dest: /usr/share/java/oracle-connector-java.jar
+        mode: 0644
+
+  when:
+    - not (skip_oracle_jdbc_driver_distribution | default(False))
+    - oracle_connector_maven_url is defined
+    - oracle_connector_maven_url != ''
+
+- name: Ensure directory for the instantclient
+  file:
+    path: /usr/share/oracle/instantclient/lib
+    state: directory
+    mode: 0755
+  when:
+    - oracle_instantclient_basic_zip is defined
+    - oracle_instantclient_sdk_zip is defined
+
+- name: Ensure unzip is available
+  ansible.builtin.package:
+    lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(60, omit) }}"
+    name: unzip
+    state: present
+  when:
+    - oracle_instantclient_basic_zip is defined
+    - oracle_instantclient_sdk_zip is defined
+
+- name: Unarchive basic instantclient
+  unarchive:
+    src: "{{ oracle_instantclient_basic_zip }}"
+    dest: /usr/share/oracle/instantclient/lib
+    extra_opts: [ "-j" ]
+  when: oracle_instantclient_basic_zip is defined
+
+- name: Unarchive sdk instantclient
+  unarchive:
+    src: "{{ oracle_instantclient_sdk_zip }}"
+    dest: /usr/share/oracle/instantclient/lib
+    extra_opts: [ "-j" ]
+  when: oracle_instantclient_sdk_zip is defined
+
+- name: Install the libaio package
+  ansible.builtin.package:
+    lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(60, omit) }}"
+    name: libaio
+    state: present

--- a/roles/rdbms/client/postgresql_connector/defaults/main.yml
+++ b/roles/rdbms/client/postgresql_connector/defaults/main.yml
@@ -1,0 +1,20 @@
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+local_temp_dir: '/tmp'
+postgresql_connector_url: https://jdbc.postgresql.org/download/postgresql-42.7.2.jar
+postgresql_connector_checksum: md5:bb897217989c97a463d8f571069d158a
+install_py3_psycopg2: false

--- a/roles/rdbms/client/postgresql_connector/meta/main.yml
+++ b/roles/rdbms/client/postgresql_connector/meta/main.yml
@@ -1,0 +1,15 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---

--- a/roles/rdbms/client/postgresql_connector/tasks/main.yml
+++ b/roles/rdbms/client/postgresql_connector/tasks/main.yml
@@ -1,0 +1,50 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Download PostgreSQL Connector
+  get_url:
+    url: "{{ postgresql_connector_url }}"
+    dest: "{{ local_temp_dir }}/postgresql-connector-java.jar"
+    checksum: "{{ postgresql_connector_checksum }}"
+    mode: 0644
+  become: no
+  run_once: true
+  delegate_to: localhost
+
+- name: Create /usr/share/java directory
+  file:
+    path: /usr/share/java
+    state: directory
+    mode: 0755
+
+- name: Copy PostgreSQL Connector jar file to correct location
+  copy:
+    src: "{{ local_temp_dir }}/postgresql-connector-java.jar"
+    dest: /usr/share/java/postgresql-connector-java.jar
+    mode: 0644
+
+# SSB will need the python3-psycopg2 connector
+
+- name: Create python3-psycopg2 directory
+  file:
+      path: "/usr/share/python3"
+      state: directory
+      mode: '777'
+  when: install_py3_psycopg2 == true
+
+- name: Install python3-psycopg2
+  shell: "pip3 install psycopg2-binary==2.8.5 -t /usr/share/python3"
+  when: install_py3_psycopg2 == true

--- a/roles/rdbms/server/defaults/defaults.yml
+++ b/roles/rdbms/server/defaults/defaults.yml
@@ -1,0 +1,19 @@
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+database_tls: false
+database_type: postgresql
+database_version: 14

--- a/roles/rdbms/server/files/utf8-template.sql
+++ b/roles/rdbms/server/files/utf8-template.sql
@@ -1,0 +1,23 @@
+-- Copyright 2021 Cloudera, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+update pg_database set datallowconn = TRUE where datname = 'template0';
+\c template0
+update pg_database set datistemplate = FALSE where datname = 'template1';
+drop database template1;
+create database template1 with template = template0 encoding = 'UTF8';
+update pg_database set datistemplate = TRUE where datname = 'template1';
+\c template1
+update pg_database set datallowconn = FALSE where datname = 'template0';
+

--- a/roles/rdbms/server/handlers/main.yml
+++ b/roles/rdbms/server/handlers/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: yum clean metadata
+  ansible.builtin.command: yum clean metadata

--- a/roles/rdbms/server/meta/main.yml
+++ b/roles/rdbms/server/meta/main.yml
@@ -1,0 +1,17 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+dependencies:
+  - role: cloudera.cluster.infrastructure.ca_common

--- a/roles/rdbms/server/tasks/main.yml
+++ b/roles/rdbms/server/tasks/main.yml
@@ -1,0 +1,32 @@
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Include database type variables
+  include_vars:
+    file: "{{ database_type }}/common.yml"
+    
+- name: Include database type and OS specific variables
+  include_vars:
+    file: "{{ item }}"
+  with_first_found:
+      - "{{ database_type }}/{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml" 
+      - "{{ database_type }}/{{ ansible_os_family }}.yml"
+
+- name: Install database
+  include_tasks:
+    file: "{{ item }}"
+  with_first_found:
+    - "{{ database_type }}/{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ database_type }}/{{ ansible_os_family }}.yml"

--- a/roles/rdbms/server/tasks/mariadb/Debian.yml
+++ b/roles/rdbms/server/tasks/mariadb/Debian.yml
@@ -1,0 +1,31 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install MariaDB apt key
+  apt_key:
+    url: https://mariadb.org/mariadb_release_signing_key.asc
+    state: present
+  when: not (skip_rdbms_repo_setup | default(False))
+
+- name: Install MariaDB apt repository
+  apt_repository:
+    repo: deb [arch=amd64,arm64,ppc64el] https://downloads.mariadb.com/MariaDB/mariadb-{{ database_version }}/repo/ubuntu/ bionic main
+    state: present
+  when: not (skip_rdbms_repo_setup | default(False))
+
+- name: Install MariaDB
+  include_role:
+    name: ansible-role-mysql

--- a/roles/rdbms/server/tasks/mariadb/RedHat.yml
+++ b/roles/rdbms/server/tasks/mariadb/RedHat.yml
@@ -1,0 +1,33 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install MariaDB repository
+  yum_repository:
+    name: MariaDB
+    description: MariaDB {{ database_version }} repository for RHEL
+    baseurl: https://yum.mariadb.org/{{ database_version }}/rhel{{ ansible_distribution_major_version }}-amd64
+    gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+  when: not (skip_rdbms_repo_setup | default(False))
+ 
+- name: Disable modularity appstream, when el8 
+  command: yum -y module disable mysql mariadb
+  when:    
+    - not (skip_rdbms_repo_setup | default(False))
+    - ansible_distribution_major_version == "8"
+    
+- name: Install Mariadb
+  include_role:
+    name: ansible-role-mysql

--- a/roles/rdbms/server/tasks/mysql/RedHat.yml
+++ b/roles/rdbms/server/tasks/mysql/RedHat.yml
@@ -1,0 +1,41 @@
+# Copyright 2024 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Import GPG Key
+  rpm_key:
+    key: "{{ mysql_repo_key }}"
+    state: present
+  when: 
+    - not (skip_rdbms_repo_setup | default(False))
+
+- name: Install MySQL repository
+  yum:
+    name: "{{ mysql_repo }}"
+    update_cache: true
+    lock_timeout: 180
+    state: present 
+  when: 
+    - not (skip_rdbms_repo_setup | default(False))
+    
+- name: Disable modularity appstream, when el8 
+  command: yum -y module disable mysql mariadb
+  when:    
+    - not (skip_rdbms_repo_setup | default(False))
+    - ansible_distribution_major_version == "8"
+    
+- name: Install MySQL
+  include_role:
+    name: ansible-role-mysql

--- a/roles/rdbms/server/tasks/postgresql/Debian.yml
+++ b/roles/rdbms/server/tasks/postgresql/Debian.yml
@@ -1,0 +1,40 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install PostgreSQL apt key
+  apt_key:
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    state: present
+  when: not (skip_rdbms_repo_setup | default(False))
+
+- name: Install PostgreSQL apt repository
+  apt_repository:
+    repo: "deb https://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
+    state: present
+  when: not (skip_rdbms_repo_setup | default(False))
+
+- name: Install PostgreSQL
+  include_role:
+    name: geerlingguy.postgresql
+
+- name: Install python-psycopg2
+  ansible.builtin.pip:
+    name: psycopg2-binary
+    state: latest
+
+- name: Fix UTF-8 template
+  include_tasks:
+    file: template_fix.yml

--- a/roles/rdbms/server/tasks/postgresql/RedHat.yml
+++ b/roles/rdbms/server/tasks/postgresql/RedHat.yml
@@ -1,0 +1,58 @@
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install PostgreSQL common repository
+  yum_repository:
+    name: pgdg-common
+    description: PostgreSQL common for RHEL/CentOS
+    baseurl: https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-$releasever-$basearch
+    gpgkey: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
+  when: not (skip_rdbms_repo_setup | default(False))
+
+- name: Install PostgreSQL version repository
+  yum_repository:
+    name: pgdg
+    description: PostgreSQL {{ postgresql_version }} for RHEL/CentOS
+    baseurl: https://download.postgresql.org/pub/repos/yum/{{ postgresql_version }}/redhat/rhel-$releasever-$basearch
+    gpgkey: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
+  when: not (skip_rdbms_repo_setup | default(False))
+
+- name: disable default Postgres module in Rhel 8
+  command: dnf module disable -y postgresql
+  register: __postgres_module_result
+  changed_when:
+    - '"Disabling modules" in __postgres_module_result.stdout'
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version | int >= 8
+
+- name: Install PostgreSQL
+  include_role:
+    name: geerlingguy.postgresql
+
+- name: Fix UTF-8 template
+  include_tasks:
+    file: postgresql/template_fix.yml
+
+- name: Remove repositories and clean metadata
+  yum_repository:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - pgdg-common
+    - pgdg
+  when: not (skip_rdbms_repo_setup | default(False))
+  notify: yum clean metadata

--- a/roles/rdbms/server/tasks/postgresql/template_fix.yml
+++ b/roles/rdbms/server/tasks/postgresql/template_fix.yml
@@ -1,0 +1,35 @@
+# Copyright 2023 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Copy SQL to change template to UTF-8
+  copy:
+    src: files/utf8-template.sql
+    dest: "{{ local_temp_dir }}"
+    owner: postgres
+    group: postgres
+    mode: 0660
+
+- name: Run SQL to change template to UTF-8
+  command: "psql -f {{ local_temp_dir }}/utf8-template.sql"
+  become: yes
+  become_user: postgres
+
+- name: Remove SQL file
+  file:
+    path: "{{ local_temp_dir }}/utf8-template.sql"
+    state: absent
+  become: yes
+  become_user: postgres

--- a/roles/rdbms/server/templates/cloudera.cnf
+++ b/roles/rdbms/server/templates/cloudera.cnf
@@ -1,0 +1,26 @@
+[mysqld]
+log_bin_trust_function_creators = 1
+{% if database_tls %}
+# SSL configuration
+ssl_ca = {{ tls_chain_path }}
+ssl_cert = {{ tls_cert_path_generic }}
+ssl_key = {{ tls_key_path_plaintext_generic }}
+{% if database_version is version('8.0','>=') %}
+require_secure_transport = {{ mysql_require_secure_transport | default('OFF') }}
+{% endif %}
+{% if database_version is version('10.5.2','>=') %}
+require_secure_transport = {{ mysql_require_secure_transport | default('OFF') }}
+{% endif %}
+{% if mysql_ssl_cipher is defined  %}
+ssl_cipher = {{ mysql_ssl_cipher }}
+{% endif %}
+{% if mysql_ssl_crl is defined %}
+ssl_crl = {{ mysql_ssl_crl }}
+{% endif %}
+{% if mysql_ssl_crlpath is defined  %}
+ssl_crlpath = {{ mysql_ssl_crlpath  }}
+{% endif %}
+{% if mysql_tls_version is defined %}
+tls_version = {{ mysql_tls_version }}
+{% endif %}
+{% endif %}

--- a/roles/rdbms/server/vars/mariadb/Debian.yml
+++ b/roles/rdbms/server/vars/mariadb/Debian.yml
@@ -1,0 +1,5 @@
+---
+mysql_packages:
+  - mariadb-client
+  - mariadb-server
+  - python-mysqldb

--- a/roles/rdbms/server/vars/mariadb/RedHat-7.yml
+++ b/roles/rdbms/server/vars/mariadb/RedHat-7.yml
@@ -1,0 +1,7 @@
+---
+mysql_packages:
+  - mariadb
+  - mariadb-server
+  - mariadb-libs
+  - MySQL-python
+  - perl-DBD-MySQL

--- a/roles/rdbms/server/vars/mariadb/RedHat-8.yml
+++ b/roles/rdbms/server/vars/mariadb/RedHat-8.yml
@@ -1,0 +1,7 @@
+---
+mysql_packages:
+  - mariadb
+  - mariadb-server
+  - mariadb-connector-c
+  - python3-PyMySQL
+  - perl-DBD-MySQL

--- a/roles/rdbms/server/vars/mariadb/RedHat-9.yml
+++ b/roles/rdbms/server/vars/mariadb/RedHat-9.yml
@@ -1,0 +1,7 @@
+---
+mysql_packages:
+  - mariadb
+  - mariadb-server
+  - mariadb-connector-c
+  - python3-PyMySQL
+  - perl-DBD-MySQL

--- a/roles/rdbms/server/vars/mariadb/common.yml
+++ b/roles/rdbms/server/vars/mariadb/common.yml
@@ -1,0 +1,12 @@
+---
+mysql_daemon: mariadb
+mysql_slow_query_log_file: /var/log/mysql-slow.log
+mysql_log_error: /var/log/mariadb/mariadb.log
+mysql_syslog_tag: mariadb
+mysql_pid_file: /var/run/mariadb/mariadb.pid
+mysql_config_file: /etc/my.cnf
+mysql_config_include_dir: /etc/my.cnf.d
+mysql_socket: /var/lib/mysql/mysql.sock
+mysql_config_include_files:
+  - src: "cloudera.cnf"
+    force: true

--- a/roles/rdbms/server/vars/mysql/Debian.yml
+++ b/roles/rdbms/server/vars/mysql/Debian.yml
@@ -1,0 +1,6 @@
+---
+mysql_repo: https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb
+mysql_packages:
+  - mariadb-client
+  - mariadb-server
+  - python-mysqldb

--- a/roles/rdbms/server/vars/mysql/RedHat-7.yml
+++ b/roles/rdbms/server/vars/mysql/RedHat-7.yml
@@ -1,0 +1,7 @@
+mysql_repo: https://repo.mysql.com/mysql80-community-release-el7.rpm 
+
+mysql_packages:
+  - mysql
+  - mysql-server
+  - MySQL-python
+  - perl-DBD-MySQL

--- a/roles/rdbms/server/vars/mysql/RedHat-8.yml
+++ b/roles/rdbms/server/vars/mysql/RedHat-8.yml
@@ -1,0 +1,8 @@
+mysql_repo: https://repo.mysql.com/mysql80-community-release-el8.rpm 
+
+mysql_packages:
+  - mysql
+  - mysql-server
+  - mysql-connector-c++
+  - python3-PyMySQL
+  - perl-DBD-MySQL

--- a/roles/rdbms/server/vars/mysql/RedHat-9.yml
+++ b/roles/rdbms/server/vars/mysql/RedHat-9.yml
@@ -1,0 +1,8 @@
+mysql_repo: https://repo.mysql.com/mysql80-community-release-el9.rpm 
+
+mysql_packages:
+  - mysql
+  - mysql-server
+  - mysql-connector-c++
+  - python3-PyMySQL
+  - perl-DBD-MySQL

--- a/roles/rdbms/server/vars/mysql/common.yml
+++ b/roles/rdbms/server/vars/mysql/common.yml
@@ -1,0 +1,13 @@
+---
+mysql_repo_key: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+
+mysql_root_password: 'Super$ecret1'
+mysql_user_password: 'Super$ecret1'
+mysql_daemon: mysqld
+mysql_log_error: /var/log/mysqld.log
+mysql_syslog_tag: mysqld
+mysql_pid_file: /var/run/mysqld/mysqld.pid
+mysql_socket: /var/lib/mysql/mysql.sock
+mysql_config_include_files:
+  - src: "cloudera.cnf"
+    force: true

--- a/roles/rdbms/server/vars/postgresql/Debian.yml
+++ b/roles/rdbms/server/vars/postgresql/Debian.yml
@@ -1,0 +1,23 @@
+# Copyright 2024 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+postgresql_version: "{{ database_version }}"
+postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
+postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
+postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"
+postgresql_packages:
+  - "postgresql-{{ postgresql_version }}"
+  - "postgresql-contrib-{{ postgresql_version }}"
+  - "postgresql-server-dev-{{ postgresql_version }}"

--- a/roles/rdbms/server/vars/postgresql/RedHat.yml
+++ b/roles/rdbms/server/vars/postgresql/RedHat.yml
@@ -1,0 +1,28 @@
+# Copyright 2024 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+postgresql_version: "{{ database_version }}"
+postgresql_data_dir: /var/lib/pgsql/{{ postgresql_version }}/data
+postgresql_bin_path: /usr/pgsql-{{ postgresql_version }}/bin
+postgresql_config_path: /var/lib/pgsql/{{ postgresql_version }}/data
+postgresql_daemon: postgresql-{{ postgresql_version }}.service
+# Removed devel package as avoids dependency on perl-IPC-run in pg 12+
+postgresql_packages:
+  - postgresql{{ postgresql_version | regex_replace('\.','') }}
+  - postgresql{{ postgresql_version | regex_replace('\.','') }}-server
+  - postgresql{{ postgresql_version | regex_replace('\.','') }}-libs
+  - postgresql{{ postgresql_version | regex_replace('\.','') }}-contrib
+#  - postgresql{{ postgresql_version | regex_replace('\.','') }}-devel
+postgresql_python_library: python-psycopg2

--- a/roles/rdbms/server/vars/postgresql/common.yml
+++ b/roles/rdbms/server/vars/postgresql/common.yml
@@ -1,0 +1,23 @@
+---
+postgresql_global_config_options:
+  - option: log_directory
+    value: 'log'
+  - option: listen_addresses
+    value: '*'
+  - option: max_connections
+    value: 300
+  - option: ssl
+    value: "{{ 'on' if database_tls else 'off' }}"
+  - option: ssl_cert_file
+    value: "{{ tls_cert_path_generic if database_tls else None }}"
+  - option: ssl_key_file
+    value: "{{ tls_key_path_plaintext_generic if database_tls else None }}"
+  - option: ssl_ca_file
+    value: "{{ tls_chain_path if database_tls else None }}"
+
+postgresql_hba_entries:
+  - {type: local, database: all, user: postgres, auth_method: peer}
+  - {type: local, database: all, user: all, auth_method: peer}
+  - {type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5}
+  - {type: host, database: all, user: all, address: '::1/128', auth_method: md5}
+  - {type: host, database: all, user: all, address: '0.0.0.0/0', auth_method: md5}


### PR DESCRIPTION
- Migrates rdbms roles to cloudera.exe collections

Tested:
RHEL8 & 9 - Mariadb 10.6, Postgresql 14, MySQL 8.0 -Untested:
RHEL7, Debian

-Removes MySQL 5.7 support

-Fixes MySQL 8 AppStream module Errors from cloudera-labs/cloudera.cluster#186

Updated Dependencies (to support rhel9 & other fixes): roles:
geerlingguy.postgres 3.5.0
geerlingguy.mysql ( cldr-labs patched)

collections
community.crypto: 2.17.1
community.mysql: 3.8.0
community.postgresql: 3.3.0